### PR TITLE
feat: add-only-uncommitted  - Add only-uncommitted flag to identify uncommitted changes only

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@
   - [Steps](#steps)
 - [Troubleshooting](#troubleshooting)
 - [License](#license)
+- [Contribute](#contribute)
 
 ## Features
 
 - **Analyze Specific Components**: Find out which Next.js pages are affected by changes in a specific component.
 - **Git Integration**: Compare changes between Git commits or branches to identify affected pages.
 - **Include Uncommitted Changes**: Optionally include uncommitted changes in your analysis.
+- **Only Uncommitted Changes**: Analyze only uncommitted changes against a base commit or branch.
 - **Customizable**: Supports custom configuration for page directories and file extensions to exclude.
 - **TypeScript Support**: Works seamlessly with TypeScript and recognizes path aliases from `tsconfig.json`.
 - **Verbose Logging**: Provides detailed logs for better debugging and analysis.
@@ -83,9 +85,10 @@ next-affected run [componentPath] [options]
 ### Options
 
 - `-p, --project <path>`: Path to the Next.js project. Defaults to `.` (current directory).
-- `-b, --base <commit>`: Base commit or branch to compare changes.
+- `-b, --base <commit>`: Base commit or branch to compare changes. **Required when using `--only-uncommitted`**.
 - `-h, --head <commit>`: Head commit or branch to compare changes. Defaults to `HEAD`.
 - `-u, --uncommitted`: Include uncommitted changes in the analysis.
+- `-o, --only-uncommitted`: Analyze only uncommitted changes against the base. **Requires `--base`**.
 - `-d, --depth <number>`: Max depth for dependency traversal.
 - `-v, --verbose`: Enable verbose logging.
 
@@ -107,6 +110,16 @@ Analyze all changes including uncommitted (local) changes, listing the affected 
 next-affected run --uncommitted --base main
 ```
 
+#### Analyze Only Uncommitted Changes
+
+Analyze only the uncommitted changes in your working directory against the `main` branch:
+
+```bash
+next-affected run --only-uncommitted --base main
+```
+
+> **Note:** The `--only-uncommitted` flag requires the `--base` (`-b`) flag to specify the base commit or branch.
+
 #### Compare Changes Between Current Branch and `main`
 
 Analyze all changes between your current branch and `main`, listing the affected pages:
@@ -127,6 +140,14 @@ next-affected run --base commit1 --head commit2
 
 ```bash
 next-affected run --project /path/to/your/project --verbose
+```
+
+### Additional Help
+
+For more detailed help and options, you can run:
+
+```bash
+next-affected run --help
 ```
 
 ## Configuration
@@ -165,7 +186,7 @@ You can edit the `next-affected.config.json` file to suit your project's structu
 ### Steps:
 
 1. **Build Dependency Graph**: Uses [madge](https://github.com/pahen/madge) to build the dependency graph of your project.
-2. **Determine Changed Files**: If using Git comparison mode (`--base`), it determines the list of changed files between the two commits or branches. If `--uncommitted` is specified, it also includes uncommitted changes and untracked files.
+2. **Determine Changed Files**: If using Git comparison mode (`--base`), it determines the list of changed files between the two commits or branches. If `--uncommitted` or `--only-uncommitted` is specified, it also includes uncommitted changes and untracked files.
 3. **Traverse Dependencies**: For each changed file or specified component, it traverses the dependency graph to find all dependent modules, up to the specified depth.
 4. **Identify Affected Pages**: Filters the dependent modules to identify which are Next.js pages based on the configured `pagesDirectories`.
 
@@ -174,6 +195,7 @@ You can edit the `next-affected.config.json` file to suit your project's structu
 - **No Affected Pages Found**: Ensure that the paths in `pagesDirectories` are correct and point to your Next.js pages.
 - **Errors Executing Git Command**: Verify that the commits or branches specified in `--base` and `--head` exist and are accessible.
 - **Including Uncommitted Changes Not Working**: Make sure you have saved your changes and that they are within the project directory specified.
+- **`--only-uncommitted` Flag Not Working**: Ensure you are also specifying the `--base` flag when using `--only-uncommitted`.
 - **Verbose Logging**: Use the `--verbose` flag to enable detailed logging, which can help identify issues.
 
 ## License

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,7 +8,7 @@ const program = new commander_1.Command();
 program
     .name("next-affected")
     .description("List Next.js pages affected by changes")
-    .version("0.1.0");
+    .version("0.1.1");
 program
     .command("init")
     .description("Initialize next-affected configuration")
@@ -24,13 +24,15 @@ program
     .option("-d, --depth <number>", "Max depth for dependency traversal", parseInt)
     .option("-v, --verbose", "Enable verbose logging")
     .option("-u, --uncommitted", "Include uncommitted changes")
+    .option("-o, --only-uncommitted", "Only include uncommitted changes")
     .on("--help", () => {
     console.log("");
     console.log("Examples:");
     console.log("  $ next-affected run src/components/Button.tsx");
     console.log("  $ next-affected run --base main");
     console.log("  $ next-affected run --base commit1 --head commit2");
-    console.log("  $ next-affected run --include-uncommitted");
+    console.log("  $ next-affected run --uncommitted");
+    console.log("  $ next-affected run --only-uncommitted");
 })
     .action(async (componentPath, options) => {
     await (0, run_1.runNextAffected)(componentPath, options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-affected",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CLI tool to list Next.js pages affected by changes",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name("next-affected")
   .description("List Next.js pages affected by changes")
-  .version("0.1.0");
+  .version("0.1.1");
 
 program
   .command("init")
@@ -18,7 +18,7 @@ program
     initConfig();
   });
 
-program
+  program
   .command("run [componentPath]")
   .description("List Next.js pages affected by changes")
   .option("-p, --project <path>", "Path to the Next.js project", ".")
@@ -31,13 +31,15 @@ program
   )
   .option("-v, --verbose", "Enable verbose logging")
   .option("-u, --uncommitted", "Include uncommitted changes")
+  .option("-o, --only-uncommitted", "Only include uncommitted changes")
   .on("--help", () => {
     console.log("");
     console.log("Examples:");
     console.log("  $ next-affected run src/components/Button.tsx");
     console.log("  $ next-affected run --base main");
     console.log("  $ next-affected run --base commit1 --head commit2");
-    console.log("  $ next-affected run --include-uncommitted");
+    console.log("  $ next-affected run --uncommitted");
+    console.log("  $ next-affected run --only-uncommitted");
   })
   .action(async (componentPath: string | undefined, options: any) => {
     await runNextAffected(componentPath, options);

--- a/src/modules/run.spec.ts
+++ b/src/modules/run.spec.ts
@@ -102,6 +102,7 @@ describe("runNextAffected", () => {
       base: "main",
       head: "HEAD",
       includeUncommitted: false,
+      onlyUncommitted: false,
       projectDir: "/resolved/path",
     });
     expect(findAffectedPages).toHaveBeenCalledWith(

--- a/src/modules/run.ts
+++ b/src/modules/run.ts
@@ -12,6 +12,7 @@ export async function runNextAffected(
     depth?: number;
     verbose?: boolean;
     uncommitted?: boolean;
+    onlyUncommitted?: boolean;
   }
 ): Promise<void> {
   try {
@@ -75,6 +76,7 @@ export async function runNextAffected(
         head: options.head ?? "HEAD",
         projectDir: projectDir,
         includeUncommitted: options.uncommitted ?? false,
+        onlyUncommitted: options.onlyUncommitted ?? false,
       });
 
       if (changedFiles.length === 0) {


### PR DESCRIPTION
This pull request introduces a new feature to analyze only uncommitted changes and includes several updates to the `README.md` and codebase to support this functionality. The main changes include updates to the documentation, command-line options, and internal logic for handling uncommitted changes.

### Documentation Updates:
* Added new section and examples for the `--only-uncommitted` flag in `README.md`.
* Updated the options and troubleshooting sections to include the `--only-uncommitted` flag.

### Codebase Updates:
* Added `--only-uncommitted` option to the command-line interface in `src/index.ts`.
* Updated the `getChangedFiles` function to handle the `onlyUncommitted` flag in `src/modules/git.ts` .
* Updated the `runNextAffected` function to pass the `onlyUncommitted` option in `src/modules/run.ts`.

### Version Bump:
* Updated the version number in `package.json` and `src/index.ts` to `0.1.1`.