### PR TITLE
feat: exclude-paths - Add exclude paths option to config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-affected",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "CLI tool to list Next.js pages affected by changes",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ const program = new Command();
 program
   .name("next-affected")
   .description("List Next.js pages affected by changes")
-  .version("1.0.0");
+  .version("1.1.0");
 
 program
   .command("init")

--- a/src/modules/config.spec.ts
+++ b/src/modules/config.spec.ts
@@ -10,6 +10,7 @@ describe("initConfig", () => {
   const defaultConfig: NextAffectedConfig = {
     pagesDirectories: ["pages", "src/pages", "app", "src/app"],
     excludedExtensions: [".css", ".scss", ".less", ".svg", ".png", ".jpg"],
+    excludedPaths: [],
   };
 
   it("should not create the config file if it already exists", () => {
@@ -50,6 +51,7 @@ describe("loadConfig", () => {
   const defaultConfig: NextAffectedConfig = {
     pagesDirectories: ["pages", "src/pages", "app", "src/app"],
     excludedExtensions: [".css", ".scss", ".less", ".svg", ".png", ".jpg"],
+    excludedPaths: [],
   };
 
   beforeEach(() => {

--- a/src/modules/config.ts
+++ b/src/modules/config.ts
@@ -7,6 +7,7 @@ export function initConfig(): void {
   const defaultConfig: NextAffectedConfig = {
     pagesDirectories: ["pages", "src/pages", "app", "src/app"],
     excludedExtensions: [".css", ".scss", ".less", ".svg", ".png", ".jpg"],
+    excludedPaths: [],
   };
 
   if (fs.existsSync(configFileName)) {
@@ -29,6 +30,7 @@ export function loadConfig(projectDir: string): NextAffectedConfig {
     return {
       pagesDirectories: ["pages", "src/pages", "app", "src/app"],
       excludedExtensions: [".css", ".scss", ".less", ".svg", ".png", ".jpg"],
+      excludedPaths: [],
     };
   }
 }

--- a/src/modules/graph.spec.ts
+++ b/src/modules/graph.spec.ts
@@ -21,6 +21,7 @@ describe("findAffectedPages", () => {
   const mockConfig: NextAffectedConfig = {
     pagesDirectories: ["pages"],
     excludedExtensions: [".css"],
+    excludedPaths: [],
   };
   const mockProjectDir = "/path/to/project";
   const mockChangedComponent = "file1.ts";

--- a/src/modules/run.spec.ts
+++ b/src/modules/run.spec.ts
@@ -63,6 +63,7 @@ describe("runNextAffected", () => {
     mockedLoadConfig.mockReturnValue({
       pagesDirectories: ["pages"],
       excludedExtensions: [".css"],
+      excludedPaths: [],
     });
     mockedGetDependencyGraph.mockResolvedValue({
       moduleA: [],

--- a/src/modules/utils.spec.ts
+++ b/src/modules/utils.spec.ts
@@ -16,6 +16,7 @@ describe("isPage", () => {
   const config: NextAffectedConfig = {
     pagesDirectories: ["pages", "src/pages"],
     excludedExtensions: [".css", ".scss"],
+    excludedPaths: [],
   };
 
   beforeEach(() => {
@@ -50,6 +51,7 @@ describe("getRouteFromPage", () => {
   const config: NextAffectedConfig = {
     pagesDirectories: ["pages", "src/pages"],
     excludedExtensions: [".css", ".scss"],
+    excludedPaths: [],
   };
 
   beforeEach(() => {
@@ -100,17 +102,18 @@ describe("shouldExcludeModule", () => {
   const config: NextAffectedConfig = {
     pagesDirectories: ["pages", "src/pages"],
     excludedExtensions: [".css", ".scss"],
+    excludedPaths: [],
   };
 
   it("should return true if the module path ends with an excluded extension", () => {
     const modulePath = "/project/styles/main.css";
-
-    expect(shouldExcludeModule(modulePath, config)).toBe(true);
+    const projectDir = "/project";
+    expect(shouldExcludeModule(modulePath, config, projectDir)).toBe(true);
   });
 
   it("should return false if the module path does not end with an excluded extension", () => {
     const modulePath = "/project/pages/home.js";
-
-    expect(shouldExcludeModule(modulePath, config)).toBe(false);
+    const projectDir = "/project";
+    expect(shouldExcludeModule(modulePath, config, projectDir)).toBe(false);
   });
 });

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -38,12 +38,32 @@ export function getRouteFromPage(
 
 export function normalizePath(filePath: string): string {
   const absolutePath = path.resolve(filePath);
-  return absolutePath.replace(/\\/g, "/");
+  return absolutePath?.replace(/\\/g, "/");
 }
 
 export function shouldExcludeModule(
   modulePath: string,
-  config: NextAffectedConfig
+  config: NextAffectedConfig,
+  projectDir: string
 ): boolean {
-  return config.excludedExtensions.some((ext) => modulePath.endsWith(ext));
+  // Check if the module has an excluded extension
+  if (config.excludedExtensions.some((ext) => modulePath.endsWith(ext))) {
+    return true;
+  }
+
+  const normalizedModulePath = normalizePath(modulePath);
+
+  // Check if the module is within any of the excluded paths
+  if (config.excludedPaths) {
+    for (const excludedPath of config.excludedPaths) {
+      const normalizedExcludedPath = normalizePath(
+        path.resolve(projectDir, excludedPath)
+      );
+      if (normalizedModulePath.startsWith(normalizedExcludedPath)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 export interface NextAffectedConfig {
   pagesDirectories: string[];
   excludedExtensions: string[];
+  excludedPaths?: string[];
 }


### PR DESCRIPTION
This pull request introduces several updates to the `next-affected` CLI tool, including a version bump and enhancements to the configuration options. The most significant changes include adding support for excluding specific paths, updating the version number, and modifying the dependency graph filtering logic.

### Version Update:
* [`package.json`]: Updated the version from `1.0.0` to `1.1.0`.
* [`src/index.ts`]: Updated the version in the command description to `1.1.0`.

### Configuration Enhancements:
* [`src/types/index.ts`]: Added an optional `excludedPaths` property to the `NextAffectedConfig` interface.
* [`src/modules/config.ts`]: Included `excludedPaths` in the default configuration for both `initConfig` and `loadConfig` functions. 
### Dependency Graph Filtering:
* [`src/modules/graph.ts`]: Modified the `getDependencyGraph` function to filter out modules and dependencies based on the new `excludedPaths` configuration.
* [`src/modules/graph.ts`]: Updated the `findAffectedPages` function to respect the `excludedPaths` configuration when traversing dependencies. 

### Test Updates:
* Updated various test files to include the `excludedPaths` property in the mock configuration:
  * `src/modules/config.spec.ts`
  * `src/modules/graph.spec.ts`
  * `src/modules/run.spec.ts`
  * `src/modules/utils.spec.ts`

### Utility Function Enhancements:
* [`src/modules/utils.ts`]: Enhanced the `normalizePath` and `shouldExcludeModule` functions to handle the new `excludedPaths` configuration.